### PR TITLE
bitpay-cli: email is only required for login command

### DIFF
--- a/bin/bitpay.js
+++ b/bin/bitpay.js
@@ -16,8 +16,7 @@ bitpay
   .version('0.0.2')
   .option('-o, --output [directory]', 'export directory for keys', HOME + '/.bitpay')
   .option('-i, --input [directory]', 'import directory for keys', HOME + '/.bitpay')
-  .option('-p, --password [password]', 'password for encrypting/decrypting your key', '')
-  .option('-e, --email [email]', 'your bitpay email address');
+  .option('-p, --password [password]', 'password for encrypting/decrypting your key', '');
 
 bitpay
   .command('keygen')
@@ -45,8 +44,9 @@ bitpay
 bitpay
   .command('login')
   .description('associate client identity with your bitpay account')
-  .action(function() {
-    if (!bitpay.email) {
+  .option('-e, --email <email>', 'your bitpay email address')
+  .action(function(env) {
+    if (!env.email) {
       return console.log('Error:', 'You must supply your BitPay email address')
     }
     if (!fs.existsSync(bitpay.input + '/api.key')) {
@@ -61,7 +61,7 @@ bitpay
     // associate key
     client.as('public').post('clients', {
       id: sin,
-      email: bitpay.email,
+      email: env.email,
       label: 'node-bitpay-client'
     }, function(err, result) {
       if (err) return console.log('Error:', err.error);


### PR DESCRIPTION
Move the "-e|--email" option to the "login" command since no other
command requires it.

A tricky part is to get the option values out of the commander library.
Apparently top level ("program" options) are accessed through the
program's name (here e.g. "bitpay.optionname"), while command-specific
options are passed to the .action function (in this patch e.g.
"env.optionname"). This means one has to be mindful whether an option
is global (accessible all through the "program") or just within the option
and retrieve the option value accordingly.

Also changed "[email]" to "<email>", meaning that the email value is a
required parameter of "-e|--email" option (ie. "bitpay login -e" is not
a valid command when using "<email>" in the settings, while it would be
valid using the previous "[email]" form. This affects the other options
as well, but that's beyond the scope of this patch.

Unfortunately as I see commander does not allow (yet) for making flags
required (i.e. to make it invalid to call "bitpay login" without "-e"),
so internal checks are still needed. See more at the upstream issue
tracker of visionmedia/commander.js/issues/44

Patch is also related to #25.

Signed-off-by: Gergely Imreh imrehg@gmail.com
