### PR TITLE
Add error handling to examples

### DIFF
--- a/examples/accept-overpayment.js
+++ b/examples/accept-overpayment.js
@@ -12,6 +12,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices/' + process.argv[2], function(err, invoice) {

--- a/examples/apply-late-transaction.js
+++ b/examples/apply-late-transaction.js
@@ -13,6 +13,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices/' + process.argv[2], function(err, invoice) {

--- a/examples/cancel-payout-request.js
+++ b/examples/cancel-payout-request.js
@@ -8,6 +8,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('payroll').get('payouts', { status: 'new' }, function(err, requests) {

--- a/examples/create-bill.js
+++ b/examples/create-bill.js
@@ -8,6 +8,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   var payload = {

--- a/examples/create-draft-bill.js
+++ b/examples/create-draft-bill.js
@@ -8,6 +8,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.post('bills', function(err, bill) {

--- a/examples/create-invoice.js
+++ b/examples/create-invoice.js
@@ -13,6 +13,10 @@ var data = {
   notificationURL: 'http://your-ipn-server'
 };
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.post('invoices', data, function(err, invoice) {

--- a/examples/create-payout-request.js
+++ b/examples/create-payout-request.js
@@ -32,6 +32,10 @@ var data = {
   ]
 };
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('payroll').post('payouts', data, function(err, payoutrequest) {

--- a/examples/get-bills.js
+++ b/examples/get-bills.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('bills', function(err, data) {

--- a/examples/get-invoice-by-id.js
+++ b/examples/get-invoice-by-id.js
@@ -12,6 +12,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices/'+process.argv[2], function(err, data) {

--- a/examples/get-invoice-events.js
+++ b/examples/get-invoice-events.js
@@ -12,6 +12,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices/'+process.argv[2]+'/events', function(err, data) {

--- a/examples/get-invoices-then-get-refund.js
+++ b/examples/get-invoices-then-get-refund.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices', function(err, data) {

--- a/examples/get-invoices.js
+++ b/examples/get-invoices.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   var today      = new Date().getTime();

--- a/examples/get-ledger-entries.js
+++ b/examples/get-ledger-entries.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   var today      = new Date().getTime();

--- a/examples/get-ledgers.js
+++ b/examples/get-ledgers.js
@@ -8,6 +8,10 @@ var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 var async      = require('async');
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   var today      = new Date().getTime();

--- a/examples/get-organizations.js
+++ b/examples/get-organizations.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('user').get('orgs', function(err, data) {

--- a/examples/get-orphan-status.js
+++ b/examples/get-orphan-status.js
@@ -12,6 +12,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
   client.get('invoices/' + process.argv[2], function(err, invoice) {
     if(err) console.log(err);

--- a/examples/get-payout-by-id.js
+++ b/examples/get-payout-by-id.js
@@ -13,6 +13,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
   client.as('payroll').get('payouts/' + process.argv[2], function(err, request) {
     console.log(err || request);

--- a/examples/get-payout-request.js
+++ b/examples/get-payout-request.js
@@ -12,6 +12,11 @@ if (process.argv.length < 3) {
   console.log('usage: get-payout-request.js [payoutId]');
   return;
 }
+
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('payroll').get('payouts/' + process.argv[2], { status: 'new' }, function(err, requests) {

--- a/examples/get-payouts.js
+++ b/examples/get-payouts.js
@@ -8,6 +8,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('payroll').get('payouts', { status: 'new' }, function(err, request) {

--- a/examples/get-sins.js
+++ b/examples/get-sins.js
@@ -8,6 +8,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('user').get('keys', function(err, sins) {

--- a/examples/get-tx-requests.js
+++ b/examples/get-tx-requests.js
@@ -13,6 +13,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices/' + process.argv[2], function(err, invoice) {

--- a/examples/get-user.js
+++ b/examples/get-user.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('user').get('user', function(err, data) {

--- a/examples/invalidate-sin.js
+++ b/examples/invalidate-sin.js
@@ -8,6 +8,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('keys', function(err, sins) {

--- a/examples/resend-invoice-ipn.js
+++ b/examples/resend-invoice-ipn.js
@@ -12,6 +12,10 @@ if (process.argv.length < 3) {
   return;
 }
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('invoices/' + process.argv[2], function(err, invoice) {

--- a/examples/streaming-response.js
+++ b/examples/streaming-response.js
@@ -22,6 +22,10 @@ parser.on('end', function() {
   console.log('Streamed ' + count + ' invoices!');
 });
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
   client.get('invoices').pipe(parser);
 });

--- a/examples/update-bill.js
+++ b/examples/update-bill.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.get('bills', function(err, data) {

--- a/examples/update-organization.js
+++ b/examples/update-organization.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   var updateData = {

--- a/examples/update-user.js
+++ b/examples/update-user.js
@@ -7,6 +7,10 @@ var config     = require('../config');
 var privkey    = bitauth.decrypt(config.keyPassword, encPrivkey);
 var client     = new BitPay(privkey);
 
+client.on('error', function(err) {
+    console.log(err);
+});
+
 client.on('ready', function() {
 
   client.as('user').get('user', function(err, user) {


### PR DESCRIPTION
The BitPay client library errors are emitted as events back to the
caller. If the caller does not receives and acts on them, the outcome
is a very uninformative message like this:

```
TypeError: Uncaught, unspecified "error" event
```

To prevent this, show the error message to the caller, and hopefully
encourage better practice, this patch adds a very simple error handling
code to the examples where it would matter.

Signed-off-by: Gergely Imreh imrehg@gmail.com
