### PR TITLE
Added feature to approve client identity with email, password and two-factor code with command ′keyapprove′

### DIFF
--- a/lib/cli-utils.js
+++ b/lib/cli-utils.js
@@ -1,0 +1,48 @@
+var read = require('read');
+var fs = require('fs');
+var bitauth = require('bitauth');
+
+var CliUtils = function(bitpayInput, bitpayOutput){
+  this.input = bitpayInput;
+  this.output = bitpayOutput;
+  this.secret = null;
+  this.recursions = 1;
+  this.maxRecursions = 3;
+}
+
+CliUtils.prototype.getSecret = function(keypassword, callback){
+  var secret = null;
+  try {
+    secret = bitauth.decrypt(
+      keypassword,
+      fs.readFileSync(this.input + '/api.key').toString()
+    );
+    callback(null, secret);
+  } catch(err) {
+    callback(err, secret);
+  }
+}
+
+CliUtils.prototype.recursiveGetSecret = function(keypassword, done){
+  var self = this;
+
+  self.getSecret(keypassword, function(err, output){
+    if (err) {
+      // ask for key password
+      read({ prompt: 'Enter Key Password: ', silent: true }, function(err, input) {
+        if (err) return console.log(err);
+        if ( self.recursions < self.maxRecursions ) {
+          self.recursions++;
+          self.recursiveGetSecret(input, done);
+        } else {
+          console.log('Exiting.')
+          process.exit();
+        }
+      })
+    } else {
+      done(output)
+    }
+  })
+}
+
+module.exports = CliUtils;


### PR DESCRIPTION
Added feature to approve client identity with email, password and two-factor code with command ′keyapprove′, and added various help prompts to commands, such as asking for encryption password ( with typo check )  when generating a key, ′keygen′, and asking for the decryption password on bad decryption errors ( w/ 3 attempts ) for commands ′keyrevoke′ and ′who′. Will also ask for email address, password and two-factor code when requesting a client identity, using command ′keyapprove′ to be approved if the command args haven't been used. Added notices to commands ′login′, ′logout′  and ′whoami′ to use ′keyapprove′,  ′keyrevoke′ and ′who′ instead.
