### PR TITLE
Update package.json to include npm's bitauth.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "api"
   ],
   "dependencies": {
-    "request": "^2.34.0",
-    "read": "^1.0.5",
-    "extend": "^1.2.1",
     "async": "^0.7.0",
     "base58-native": "~0.1.4",
+    "bitauth": "^0.1.1",
     "commander": "^1.3.2",
-    "bitauth": "git+https://github.com/bitpay/bitauth.git"
+    "extend": "^1.2.1",
+    "read": "^1.0.5",
+    "request": "^2.34.0"
   },
   "analyze": false,
   "license": "MIT",


### PR DESCRIPTION
This makes node-bitpay-client utilize the `npm` version of BitAuth (rather than our git repo).
