### PR TITLE
fix resource tokens

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -116,14 +116,17 @@ RESTClient.prototype._sendRequest = function() {
     data.guid = self._createGuid();
   }
 
-  // if we are passed a token (as a facade) directly, then set the token to it
-  if (self.facade !== 'public' && self.facade !== 'user') {
-    data.token = self.facade;
-  }
+  // If we already have a resource token, then don't execute the following code
+  if(!data.token) {
+    // if we are passed a token (as a facade) directly, then set the token to it
+    if (self.facade !== 'public' && self.facade !== 'user') {
+      data.token = self.facade;
+    }
 
-  // unless a resource token is given, pass the facade token
-  if (self.tokens[self.facade]) {
-    data.token = self.tokens[self.facade];
+    // unless a resource token is given, pass the facade token
+    if (self.tokens[self.facade]) {
+      data.token = self.tokens[self.facade];
+    }
   }
 
   // start building the request options


### PR DESCRIPTION
Resource tokens were broken. For example if you do:

invoice.post('notifications', function() {});

It would use the merchant token instead of the resource token.
This code fixes the problem.
