### PR TITLE
WIP: API Sessions

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -33,7 +33,7 @@ var RESTClient = function(privateKey, options) {
   self.defaults = {
     getTokens: !!privateKey,
     signRequests: !!privateKey,
-    useSession: true
+    useSession: false
   };
 
   // override the defaults if needed and setup container for access tokens


### PR DESCRIPTION
This should not be merged in until the backend changes are running in prod.

We have removed nonces in favor of having an optional layer of security which protects against replay attacks and ensures request order. Clients can optionally create an API session (POST /sessions). In subsequent requests they can include this sessionId with a requestNumber which is incremented by one each time. Sessions expire after 15 minutes of inactivity.
