### PR TITLE
Replace process.env.platform with process.platform

### DIFF
--- a/bin/bitpay.js
+++ b/bin/bitpay.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var isWin        = process.env.platform === 'win32';
+var isWin        = process.platform === 'win32';
 var HOME         = process.env[isWin ? 'USERPROFILE' : 'HOME'];
 var bitpay       = require('commander');
 var BitPay       = require('../index');

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -6,7 +6,7 @@ var bitauth      = require('bitauth');
 var EventEmitter = require('events').EventEmitter;
 var util         = require('util');
 
-var isWin        = process.env.platform === 'win32';
+var isWin        = process.platform === 'win32';
 var HOME         = process.env[isWin ? 'USERPROFILE' : 'HOME'];
 var defaultConf  = require(HOME + '/.bitpay/config.json');
 


### PR DESCRIPTION
This should fix detection of Windows systems, allowing for a correct specification of home directories.