### PR TITLE
Handle missing config file

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -8,7 +8,15 @@ var util         = require('util');
 
 var isWin        = process.platform === 'win32';
 var HOME         = process.env[isWin ? 'USERPROFILE' : 'HOME'];
-var defaultConf  = require(HOME + '/.bitpay/config.json');
+try {
+  var defaultConf = require(HOME + '/.bitpay/config.json');
+} catch (e) {
+  var defaultConf = {
+    "apiHost": "test.bitpay.com",
+    "apiPort": 443,
+    "forceSSL": true
+  }
+}
 
 /*
 ** BitPay REST Client


### PR DESCRIPTION
Use default values from test config and prevent error if you don't have access rights to HOME dir (e.g. Heroku) and therefore config file was not properly created during installation of bitpay-rest library.